### PR TITLE
Fix  restrict-ranges examples syntax highlighting

### DIFF
--- a/docs/rules/restrict-ranges.md
+++ b/docs/rules/restrict-ranges.md
@@ -9,7 +9,7 @@ This rule aims to prevent too liberal of version ranges or branches.
 
 Examples of **incorrect** code for this rule:
 
-```json
+```js
 /* eslint restrict-ranges: [{ versionHint: "pin' }] */
 
 {
@@ -19,7 +19,7 @@ Examples of **incorrect** code for this rule:
 }
 ```
 
-```json
+```js
 /* eslint restrict-ranges: [{ versionRegex: "^[^#]+$' }] */
 
 {
@@ -31,7 +31,7 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```json
+```js
 /* eslint restrict-ranges: [{ versionHint: "pin' }] */
 
 {


### PR DESCRIPTION
This fixes the syntax highlighting in the docs for the restrict-ranges rule.

Comments aren't allowed in JSON and they were breaking the highlighting :)

### Before:

<img width="914" alt="Screen Shot 2019-09-30 at 3 52 32 PM" src="https://user-images.githubusercontent.com/602204/65922554-86f23600-e39a-11e9-8327-81d02c8c77d1.png">

### After

<img width="927" alt="Screen Shot 2019-09-30 at 3 55 37 PM" src="https://user-images.githubusercontent.com/602204/65922633-ca4ca480-e39a-11e9-85af-acde18296b71.png">
