### PR TITLE
Fix #38 restrict-ranges - typo in "carat"

### DIFF
--- a/docs/rules/restrict-ranges.md
+++ b/docs/rules/restrict-ranges.md
@@ -51,7 +51,7 @@ This rule has either an object option:
 * `"versionHint"` limit the range using semver hints
   * `"pin"` no version hints
   * `"tilde"` include `~` or pinned
-  * `"carat"` include `^`, `~`, or pinned
+  * `"caret"` include `^`, `~`, or pinned
 * `"versionRegex"` limit the range using a regular expression
 * `"pinUnstable"` no version hints for 0.x.x or prerelease
 

--- a/lib/rules/restrict-ranges.js
+++ b/lib/rules/restrict-ranges.js
@@ -26,6 +26,7 @@ const versionHint = {
   'versionHint': {
     'enum': [
       'carat',
+      'caret',
       'tilde',
       'pin'
     ]
@@ -138,6 +139,7 @@ module.exports = {
               let versionHintRegex;
               switch (versionHint) {
                 case 'carat':
+                case 'caret':
                   versionHintRegex = /^[\^~\d]/;
                   break;
                 case 'tilde':

--- a/tests/lib/rules/restrict-ranges.js
+++ b/tests/lib/rules/restrict-ranges.js
@@ -28,6 +28,21 @@ new RuleTester().run('restrict-ranges', rule, preprocess({
         options: [{ versionHint: 'carat' }]
       },
       {
+        code: '{ "dependencies": { "foo": "^1.2.3" } }',
+        filename: 'package.json',
+        options: [{ versionHint: 'caret' }]
+      },
+      {
+        code: '{ "dependencies": { "foo": "~1.2.3" } }',
+        filename: 'package.json',
+        options: [{ versionHint: 'caret' }]
+      },
+      {
+        code: '{ "dependencies": { "foo": "1.2.3" } }',
+        filename: 'package.json',
+        options: [{ versionHint: 'caret' }]
+      },
+      {
         code: '{ "dependencies": { "foo": "~1.2.3" } }',
         filename: 'package.json',
         options: [{ versionHint: 'tilde' }]
@@ -208,6 +223,18 @@ new RuleTester().run('restrict-ranges', rule, preprocess({
         filename: 'package.json',
         options: [[
           { packages: ['foo'], versionHint: 'carat' },
+          { packageRegex: 'bar', versionHint: 'pin' }
+        ]],
+        errors: [{
+          message: 'Invalid SemVer hint (pin).',
+          type: 'Literal'
+        }]
+      },
+      {
+        code: '{ "dependencies": { "foo": "^1.2.3", "bar": "^1.2.3" } }',
+        filename: 'package.json',
+        options: [[
+          { packages: ['foo'], versionHint: 'caret' },
           { packageRegex: 'bar', versionHint: 'pin' }
         ]],
         errors: [{

--- a/tests/lib/rules/restrict-ranges.js
+++ b/tests/lib/rules/restrict-ranges.js
@@ -171,6 +171,24 @@ new RuleTester().run('restrict-ranges', rule, preprocess({
           message: 'Invalid SemVer hint (pin).',
           type: 'Literal'
         }]
+      },
+      {
+        code: '{ "dependencies": { "foo": "*" } }',
+        filename: 'package.json',
+        options: [{ versionHint: 'carat' }],
+        errors: [{
+          message: 'Invalid SemVer hint (carat).',
+          type: 'Literal'
+        }]
+      },
+      {
+        code: '{ "dependencies": { "foo": "*" } }',
+        filename: 'package.json',
+        options: [{ versionHint: 'caret' }],
+        errors: [{
+          message: 'Invalid SemVer hint (caret).',
+          type: 'Literal'
+        }]
       }
     ],
     ...[ // versionRegex


### PR DESCRIPTION
- Fix typo in `restrict-ranges.md`
- Add new `caret` option
- Keep the old `carat` option to avoid API breakage
- Add missing tests for `caret`/`carat` `versionHint`

Fix #38