### PR TITLE
Preserve trailing whitespace when sorting

### DIFF
--- a/lib/rules/sort-package-json.js
+++ b/lib/rules/sort-package-json.js
@@ -20,11 +20,16 @@ module.exports = {
     }
 
     let sourceCode = context.getSourceCode();
+    let sourceCodeText = sourceCode.getText();
 
     return {
       AssignmentExpression(node) {
         let packageJsonNode = node.right;
-        let packageJsonText = sourceCode.text.substring(...packageJsonNode.range);
+
+        // When sorting the package.json text, also include any trailing whitespace because that whitespace will not be
+        // included in the packageJsonNode
+        let trailingWhitespace = /(\s*)$/.exec(sourceCodeText)[1];
+        let packageJsonText = sourceCode.getText(packageJsonNode) + trailingWhitespace;
         let sortedText = sortPackageJson(packageJsonText);
 
         if (packageJsonText !== sortedText) {
@@ -32,7 +37,10 @@ module.exports = {
             node: packageJsonNode,
             message: 'package.json is not sorted correctly.',
             fix(fixer) {
-              return fixer.replaceText(node, sortedText);
+              // fixer.replaceText(node, ...) doesn't work because "node" never contains the trailing newline in the
+              // original package.json. That newline won't get replaced, and we'll end up with an extra newline.
+              // Instead, we have to replace the entire source code range.
+              return fixer.replaceTextRange([0, sourceCodeText.length], sortedText);
             }
           });
         }

--- a/tests/lib/rules/sort-package-json.js
+++ b/tests/lib/rules/sort-package-json.js
@@ -39,6 +39,22 @@ preprocess.applyAutofixWorkaround(new RuleTester()).run('sort-package-json', rul
 }
 `
     },
+    // preserves no trailing whitespace
+    {
+      code: `{
+  "version": "1.0.0",
+  "name": "foo"
+}`,
+      filename: 'package.json',
+      errors: [{
+        message: 'package.json is not sorted correctly.',
+        type: 'ObjectExpression'
+      }],
+      output: `{
+  "name": "foo",
+  "version": "1.0.0"
+}`
+    },
     // preserves existing indentation
     {
       code: `{


### PR DESCRIPTION
Preserve any trailing whitespace in `package.json` when auto-fixing incorrectly sorted `package.json` files.