### PR TITLE
Preserve trailing whitespace when sorting (cleaner)

### DIFF
--- a/lib/processors/json.js
+++ b/lib/processors/json.js
@@ -28,13 +28,13 @@ module.exports = {
       // message.fix.range refers to indices in the processed source text, so update them to refer to the correct
       // indices in the raw source text as documented here:
       // https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
-      return {
+      return message.fix ? {
         ...message,
         fix: {
           ...message.fix,
           range: message.fix.range.map(rangePart => Math.max(0, rangePart - prefix.length))
         }
-      };
+      } : message;
     });
   },
   supportsAutofix: true

--- a/lib/processors/json.js
+++ b/lib/processors/json.js
@@ -24,7 +24,18 @@ module.exports = {
       return total.concat(next.filter(error => {
         return error.ruleId && error.ruleId.startsWith('json-files/');
       }));
-    }, []);
+    }, []).map(message => {
+      // message.fix.range refers to indices in the processed source text, so update them to refer to the correct
+      // indices in the raw source text as documented here:
+      // https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
+      return {
+        ...message,
+        fix: {
+          ...message.fix,
+          range: message.fix.range.map(rangePart => Math.max(0, rangePart - prefix.length))
+        }
+      };
+    });
   },
   supportsAutofix: true
 };

--- a/tests/lib/processors/json.js
+++ b/tests/lib/processors/json.js
@@ -34,6 +34,34 @@ describe(function() {
     expect(report.results[0].messages[0].line).to.equal(1);
   });
 
+  it('should fix issues in .json files', function() {
+    let fixerCli = new CLIEngine({
+      extensions: ['json'],
+      ignore: false,
+      rules: {
+        'json-files/sort-package-json': [2]
+      },
+      useEslintrc: false,
+      plugins: ['json-files'],
+      fix: true
+    });
+
+    let text = `{
+  "version": "1.0.0",
+  "name": "foo"
+}
+`;
+
+    let report = fixerCli.executeOnText(text, 'package.json');
+
+    expect(report.results.length).to.equal(1);
+    expect(report.results[0].output).to.equal(`{
+  "name": "foo",
+  "version": "1.0.0"
+}
+`);
+  });
+
   it('should ignore js rules on .json files', function() {
     let text = `{
   "license": "MIT"


### PR DESCRIPTION
Here's an alternative, more direct alternative to PR #87 to fix issue #39.