### PR TITLE
feat: add eol-last rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ eslint . --ext js,json
 | Rule ID | Description |
 |:--------|:------------|
 | [json-files/ensure-repository-directory](./docs/rules/ensure-repository-directory.md) | ensure repository/directory in package.json |
+| [json-files/eol-last](./docs/rules/eol-last.md) | require or disallow newline at the end of package.json |
 | [json-files/no-branch-in-dependencies](./docs/rules/no-branch-in-dependencies.md) | prevent branches in package.json dependencies |
 | [json-files/require-engines](./docs/rules/require-engines.md) | require the engines field in package.json |
 | [json-files/require-license](./docs/rules/require-license.md) | require a license in package.json |

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,0 +1,3 @@
+# require or disallow newline at the end of package.json (eol-last)
+
+Same as https://eslint.org/docs/latest/rules/eol-last, but works on JSON files.

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// eslint-disable-next-line node/no-missing-require
+const { builtinRules } = require('eslint/use-at-your-own-risk');
+
+module.exports = builtinRules.get('eol-last');

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib/rules/eol-last');
+const preprocess = require('../../helpers/preprocess');
+
+new RuleTester().run('eol-last', rule, preprocess({
+  valid: [
+    {
+      code: `{}
+`,
+      filename: 'package.json'
+    },
+    {
+      code: '{}',
+      filename: 'package.json',
+      options: ['never']
+    }
+  ],
+  invalid: [
+    {
+      code: '{}',
+      filename: 'package.json',
+      errors: [{
+        message: rule.meta.messages.missing,
+        type: Object.keys(rule.create())[0]
+      }],
+      output: `{}
+`
+    },
+    {
+      code: `{}
+`,
+      filename: 'package.json',
+      options: ['never'],
+      errors: [{
+        message: rule.meta.messages.unexpected,
+        type: Object.keys(rule.create())[0]
+      }],
+      output: '{}'
+    }
+  ]
+}));


### PR DESCRIPTION
This is a re-export of https://eslint.org/docs/latest/rules/eol-last, but works on JSON files.