### PR TITLE
Add options support for sort-package-json rule

### DIFF
--- a/docs/rules/sort-package-json.md
+++ b/docs/rules/sort-package-json.md
@@ -2,7 +2,6 @@
 
 Use [sort-package-json](https://www.npmjs.com/package/sort-package-json) to keep your keys in a predictable order.
 
-
 ## Rule Details
 
 This rule aims to enforce sorting.
@@ -27,7 +26,7 @@ Examples of **correct** code for this rule:
 
 ### Options
 
-
+Same as <https://github.com/keithamus/sort-package-json>.
 
 ## When Not To Use It
 
@@ -35,4 +34,4 @@ If you don't like the defaults of `sort-package-json`, you may not want this rul
 
 ## Further Reading
 
-https://github.com/keithamus/sort-package-json
+<https://github.com/keithamus/sort-package-json>

--- a/lib/rules/sort-package-json.js
+++ b/lib/rules/sort-package-json.js
@@ -6,11 +6,22 @@ const sortPackageJson = require('sort-package-json');
 module.exports = {
   meta: {
     docs: {
-      description: 'enforce package.json sorting'
+      description: 'Enforce package.json sorting'
     },
     fixable: 'code',
-    schema: [
-    ]
+    schema: [{
+      type: 'object',
+      properties: {
+        sortOrder: {
+          type: 'array',
+          minItems: 0,
+          items: {
+            type: 'string'
+          }
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create(context) {
@@ -20,12 +31,13 @@ module.exports = {
     }
 
     let sourceCode = context.getSourceCode();
+    let options = context.options ? context.options[0] : undefined;
 
     return {
       AssignmentExpression(node) {
         let packageJsonNode = node.right;
         let packageJsonText = sourceCode.text.substring(...packageJsonNode.range);
-        let sortedText = sortPackageJson(packageJsonText);
+        let sortedText = sortPackageJson(packageJsonText, options);
 
         if (packageJsonText !== sortedText) {
           context.report({

--- a/tests/lib/processors/json.js
+++ b/tests/lib/processors/json.js
@@ -42,7 +42,7 @@ describe(function() {
       ignore: false,
       overrideConfig: {
         rules: {
-          'json-files/sort-package-json': ['error', { sortOrder: ['name', 'version', 'license'] }]
+          'json-files/sort-package-json': [2]
         },
         plugins: ['json-files']
       },
@@ -52,8 +52,7 @@ describe(function() {
 
     let text = `{
   "version": "1.0.0",
-  "name": "foo",
-  "license": "UNLICENSED"
+  "name": "foo"
 }
 `;
 
@@ -62,8 +61,7 @@ describe(function() {
     expect(results.length).to.equal(1);
     expect(results[0].output).to.equal(`{
   "name": "foo",
-  "version": "1.0.0",
-  "license": "UNLICENSED"
+  "version": "1.0.0"
 }
 `);
   });

--- a/tests/lib/processors/json.js
+++ b/tests/lib/processors/json.js
@@ -42,7 +42,7 @@ describe(function() {
       ignore: false,
       overrideConfig: {
         rules: {
-          'json-files/sort-package-json': [2]
+          'json-files/sort-package-json': ['error', { sortOrder: ['name', 'version', 'unlicensed'] }]
         },
         plugins: ['json-files']
       },
@@ -52,7 +52,8 @@ describe(function() {
 
     let text = `{
   "version": "1.0.0",
-  "name": "foo"
+  "name": "foo",
+  "license": "UNLICENSED"
 }
 `;
 
@@ -61,7 +62,8 @@ describe(function() {
     expect(results.length).to.equal(1);
     expect(results[0].output).to.equal(`{
   "name": "foo",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "license": "UNLICENSED"
 }
 `);
   });

--- a/tests/lib/processors/json.js
+++ b/tests/lib/processors/json.js
@@ -42,7 +42,7 @@ describe(function() {
       ignore: false,
       overrideConfig: {
         rules: {
-          'json-files/sort-package-json': ['error', { sortOrder: ['name', 'version', 'unlicensed'] }]
+          'json-files/sort-package-json': ['error', { sortOrder: ['name', 'version', 'license'] }]
         },
         plugins: ['json-files']
       },

--- a/tests/lib/rules/sort-package-json.js
+++ b/tests/lib/rules/sort-package-json.js
@@ -65,6 +65,17 @@ new RuleTester().run('sort-package-json', rule, preprocess({
         type: 'ObjectExpression'
       }],
       output: '{"license":"UNLICENSED","name":"foo","version":"1.0.0"}'
+    },
+    // accepts and uses options, uses different sort order
+    {
+      code: '{"version":"1.0.0","name":"foo","license":"UNLICENSED"}',
+      filename: 'package.json',
+      options: [{ sortOrder: ['name', 'license'] }],
+      errors: [{
+        message: 'package.json is not sorted correctly.',
+        type: 'ObjectExpression'
+      }],
+      output: '{"name":"foo","license":"UNLICENSED","version":"1.0.0"}'
     }
   ]
 }));

--- a/tests/lib/rules/sort-package-json.js
+++ b/tests/lib/rules/sort-package-json.js
@@ -54,6 +54,17 @@ new RuleTester().run('sort-package-json', rule, preprocess({
     "name": "foo",
     "version": "1.0.0"
 }`
+    },
+    // accepts and uses options
+    {
+      code: '{"version":"1.0.0","name":"foo","license":"UNLICENSED"}',
+      filename: 'package.json',
+      options: [{ sortOrder: ['license', 'name'] }],
+      errors: [{
+        message: 'package.json is not sorted correctly.',
+        type: 'ObjectExpression'
+      }],
+      output: '{"license":"UNLICENSED","name":"foo","version":"1.0.0"}'
     }
   ]
 }));


### PR DESCRIPTION
- Loosely validate upstream library options (only `sortOrder` for now)
- Transparently pass options up to library from context
- Add and update tests