### PR TITLE
AssertionError [ERR_ASSERTION]: Test property 'output' matches 'code'…

### DIFF
--- a/tests/lib/rules/require-unique-dependency-names.js
+++ b/tests/lib/rules/require-unique-dependency-names.js
@@ -56,8 +56,7 @@ new RuleTester().run('require-unique-dependency-names', rule, preprocess({
       errors: [{
         message: 'Package "foo" already shows up in "dependencies".',
         type: 'Literal'
-      }],
-      output: '{ "dependencies": { "foo": "0.0.0" }, "devDependencies": { "foo": "1.0.0" } }'
+      }]
     }
   ]
 }));


### PR DESCRIPTION
…. If no autofix is expected, then omit the 'output' property or set it to null.