### PR TITLE
fix(sort-package-json): support ESLint 10 context API

### DIFF
--- a/lib/rules/sort-package-json.js
+++ b/lib/rules/sort-package-json.js
@@ -25,12 +25,12 @@ module.exports = {
   },
 
   create(context) {
-    let filename = context.getFilename();
+    let filename = context.filename ?? context.getFilename();
     if (path.basename(filename) !== 'package.json') {
       return {};
     }
 
-    let sourceCode = context.getSourceCode();
+    let sourceCode = context.sourceCode ?? context.getSourceCode();
     let options = context.options ? context.options[0] : undefined;
 
     return {

--- a/tests/lib/rules/sort-package-json.js
+++ b/tests/lib/rules/sort-package-json.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { RuleTester } = require('eslint');
+const { describe, it } = require('../../helpers/mocha');
+const { expect } = require('../../helpers/chai');
 const rule = require('../../../lib/rules/sort-package-json');
 const preprocess = require('../../helpers/preprocess');
 
@@ -79,3 +81,17 @@ new RuleTester().run('sort-package-json', rule, preprocess({
     },
   ],
 }));
+
+// ESLint 10 removed context.getFilename() and context.getSourceCode(),
+// leaving only the context.filename and context.sourceCode properties.
+describe('eslint 10 context', function() {
+  it('reads filename and source code without the removed methods', function() {
+    let context = {
+      filename: 'package.json',
+      sourceCode: { text: '{"name":"foo"}' },
+      options: [],
+    };
+
+    expect(() => rule.create(context)).to.not.throw();
+  });
+});


### PR DESCRIPTION
ESLint 10 removed the deprecated `context.getFilename()` and `context.getSourceCode()` methods, so the `sort-package-json` rule throws `TypeError: context.getFilename is not a function` when linting under v10 (#233). This reads the `context.filename` and `context.sourceCode` properties first and falls back to the old methods, which keeps it working on the older ESLint versions still in the peer range. Added a small test that drives the rule with a v10-style context.

Closes #233.