### PR TITLE
permissions:   id-token: write

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The critical requirement is the id-token: write permission, which allows GitHub Actions to generate OIDC tokens.